### PR TITLE
Optimize release_lock

### DIFF
--- a/workspace/Test_basic_osyncstream/src/globalstreambuflocks.h
+++ b/workspace/Test_basic_osyncstream/src/globalstreambuflocks.h
@@ -26,10 +26,10 @@ public:
 	}
 	void release_lock(spmx& sp,void *sbufptr){
 		guard lx{mx};
-		std::weak_ptr<std::mutex>& mxptr=thelocks[sbufptr];
+		auto iter = thelocks.find(sbufptr);
 		sp.reset();
-		if (mxptr.expired()){
-			thelocks.erase(sbufptr);
+		if (iter != thelocks.end() && iter->second.expired()){
+			thelocks.erase(iter);
 		}
 	}
 	// testing only


### PR DESCRIPTION
Avoid doing a second lookup to erase the lock from the map.

Comparing the iterator to end shouldn't be necessary, but handles the case where the ostream's stream buffer is replaced between the calls to get_lock() and release_lock().
