### PR TITLE
P0053 osyncstream streambuf implementation and updated paper

### DIFF
--- a/drafting/p0053r3_osyncstream.html
+++ b/drafting/p0053r3_osyncstream.html
@@ -1,0 +1,1293 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN"
+ "http://www.w3.org/TR/html4/strict.dtd">
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
+
+
+<style type="text/css">
+
+body {
+  color: #000000;
+  background-color: #FFFFFF;
+}
+
+del {
+  text-decoration: line-through;
+  background-color: #8B0040;
+}
+ins {
+  text-decoration: underline;
+  background-color: #C8FFC8;
+}
+highlight {
+  background-color: yellow;
+}
+
+p.example {
+  margin: 2em;
+}
+pre.example {
+  margin: 2em;
+}
+div.example {
+  margin: 2em;
+}
+
+code.extract {
+  background-color: #F5F6A2;
+}
+pre.extract {
+  margin: 2em;
+  background-color: #F5F6A2;
+  border: 1px solid #E1E28E;
+}
+
+p.function {
+}
+
+p.attribute {
+  text-indent: 3em;
+}
+
+blockquote.std {
+  color: #000000;
+  background-color: #F1F1F1;
+  border: 1px solid #D1D1D1;
+  padding: 0.5em;
+}
+
+blockquote.stddel {
+  text-decoration: line-through;
+  color: #000000;
+  background-color: #FFEBFF;
+  border: 1px solid #ECD7EC;
+  padding: 0.5em;
+}
+
+blockquote.stdins {
+  text-decoration: underline;
+  color: #000000;
+  background-color: #C8FFC8;
+  border: 1px solid #B3EBB3;
+  padding: 0.5em;
+}
+
+ul.dash {
+    list-style: none;
+    margin-left: 0;
+    padding-left: 1em;
+}
+ul.dash > li:before {
+    display: inline-block;
+    content: "--";
+    width: 1em;
+    margin-left: -1em;
+}
+
+table {
+  border: 1px solid black;
+  border-spacing: 0px;
+  margin-left: auto;
+  margin-right: auto;
+}
+th {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.2em;
+  border: none;
+}
+td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.2em;
+  border: none;
+}
+
+</style>
+
+<title>C++ Synchronized Buffered Ostream</title>
+</head>
+<body>
+<h1>C++ Synchronized Buffered Ostream</h1>
+
+<p>
+ISO/IEC JTC1 SC22 WG21 p0053r3 - 2016-11-14
+</p>
+
+<p>
+Lawrence Crowl &lt;<a href="mailto:Lawrence@Crowl.org">Lawrence@Crowl.org</a>&gt;<br/>
+Peter Sommerlad &lt;<a href="mailto:Peter.Sommerlad@hsr.ch">Peter.Sommerlad@hsr.ch</a>&gt;<br>
+Nicolai Josuttis<br/>
+Pablo Halpern &lt<a href="mailto:phalpern@halpernwightsoftware.com">phalpern@halpernwightsoftware.com</a>&gt;<br/>
+</p>
+
+<p>
+<a href="#Solution">Solution</a><br/>
+<a href="#Design">Design</a><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#Feature">Feature Test</a><br/>
+<a href="#Wording">Wording</a><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#contents">1.1 Namespaces, headers, and modifications to standard clauses [general.namespaces]</a><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#syncstream">5 Synchronized output stream [syncstream]</a><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#syncstream.overview">5.1 Overview [syncstream.overview]</a><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#syncstream.syncbuf">5.2 Class template <code>basic_syncbuf</code> [syncstream.syncbuf]</a><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#syncstream.sycnbuf.ctor">5.2.1 <code>basic_syncbuf</code> constructors [syncstream.syncbuf.ctor]</a><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#syncstream.sycnbuf.dtor">5.2.2 <code>basic_syncbuf</code> destructor [syncstream.syncbuf.dtor]</a><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#syncstream.sycnbuf.assign">5.2.3 <code>basic_syncbuf</code> assign and swap [syncstream.syncbuf.assign]</a><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#syncstream.syncbuf.mfun">5.2.4 <code>basic_syncbuf</code> member functions [syncstream.syncbuf.mfun]</a><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#syncstream.syncbuf.virtuals">5.2.5 <code>basic_syncbuf</code> overridden virtual functions [syncstream.syncbuf.virtuals]</a><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#syncstream.osyncstream">5.3 Class template <code>basic_osyncstream</code> [syncstream.osyncstream]</a><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#synstream.osyncstream.ctor">5.3.1 <code>basic_osyncstream</code> Constructors [syncstream.osyncstream.ctor]</a><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#synstream.osyncstream.dtor">5.3.2 <code>basic_osyncstream</code> Destructor [synstream.osyncstream.dtor]</a><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#synstream.osyncstream.assign">5.3.3 <code>basic_osyncstream</code> Assignment [synstream.osyncstream.assign]</a><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#syncstream.osyncstream.mfun">5.3.4 <code>basic_osyncstream</code>member functions [syncstream.osyncstream.mfun]</a><br/>
+<a href="#implementation">Implementation</a><br/>
+<a href="#Revisions">Revisions</a><br/>
+<a href="#References">References</a><br/>
+</p>
+
+<h2><a name="Introduction">Introduction</a></h2>
+
+<p>
+At present,
+some stream output operations guarantee that they will not produce race conditions,
+but do not guarantee that the effect will be sensible.
+Some form of external synchronization is required.
+Unfortunately, without a standard mechanism for synchronizing,
+independently developed software will be unable to synchronize.
+</p>
+
+<p>
+<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3535.html">
+N3535 C++ Stream Mutexes</a>
+proposed a standard mechanism for finding and sharing a mutex on streams.
+At the Spring 2013 standards meeting,
+the Concurrency Study Group requested a change
+away from a full mutex definition
+to a definition that also enabled buffering.
+</p>
+
+<p>
+<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3678.html">
+N3678 C++ Stream Guards</a>
+proposed a standard mechanism for batching operations on a stream.
+That batching may be implemented as mutexees, as buffering,
+or some combination of both.
+It was the response to the Concurrency Study Group.
+A draft of that paper was reviewed in the Library Working Group,
+who found too many open issues on what was reasonably exposed
+to the 'buffering' part.
+</p>
+
+<p>
+<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3665.html">
+N3665 Uninterleaved Sring Output Streaming</a>
+proposed making streaming of strings of length less than <code>BUFSIZ</code>
+appear uninterleaved in the output.
+It was a "minimal" functionality change to the existing standard
+to address the problem.
+The full Committee chose not to adopt that minimal solution.
+</p>
+
+<p>
+<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2013/n3750.html">N3750
+C++ Ostream Buffers</a> proposed an explicit buffering,
+at the direction of the general consensus
+in the July 2013 meeting of the Concurrency Study Group.
+In November 2014 a further updated version
+<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4187.html">N4187</a>
+was discussed in Library Evolution in Urbana
+and it was consensus to work with a library expert
+to get the naming and wording better suited to LWG expectations.
+Nico Josuttis volunteered to help the original authors.
+More information on the discussion is available at
+<a href="http://wiki.edg.com/twiki/bin/view/Wg21urbana-champaign/N4187">LEWG
+wiki</a>
+and the corresponding
+<a href="https://issues.isocpp.org/show_bug.cgi?id=20">LEWG
+bug tracker entry (20)</a>.
+This paper address issues raised with
+<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4187.html">N4187</a>.
+This paper has a change of title to reflect a change in class name,
+but contains the same fundamental approach.
+</p>
+
+
+<h2><a name="Solution">Solution</a></h2>
+
+<p>
+The following proposal is targeted for the <strong>concurrency TS, version 2</strong>.
+</p>
+
+<p>
+We propose a <code>basic_osyncstream</code>,
+that buffers output operations for a wrapped stream.
+The <code>basic_osyncstream</code>
+will atomically transfer the contents
+of an internal stream buffer
+to a <code>basic_ostream</code>'s stream buffer
+on destruction of the <code>basic_osyncstream</code>.
+</p>
+
+<p>
+The transfer on destruction
+simplifies the code and
+ensures at least some output in the presence of an exception.
+</p>
+
+<p>
+The intent is that the <code>basic_osyncstream</code>
+is an automatic-duration variable
+with a relatively small scope
+which constructs the text to appear uninterleaved.
+For example,
+</p>
+<pre class="example"><code>{
+  osyncstream bout(cout);
+  bout &lt;&lt; "Hello, " &lt;&lt; "World!" &lt;&lt; endl;
+}</code></pre>
+
+<p>or more tersely,</p>
+<pre class="example"><code>osyncstream{cout} &lt;&lt; "Hello, " &lt;&lt; "World!" &lt;&lt; endl;</code></pre>
+
+<p><highlight>
+Do we also want global variables <code>cout_sync, cerr_sync, clog_sync,
+wcout_sync, wcerr_sync,</code> and <code>wclog_sync</code>? Adding these
+would allow a further simplification,
+</highlight></p>
+<highlight><pre class="example"><highlight><code>cout_sync &lt;&lt; "Hello, " &lt;&lt; "World!" &lt;&lt; endl;</code></highlight></pre></highlight>
+
+<h2><a name="Design">Design</a></h2>
+
+<p>
+The main functionality of synchronized streams is encapsulated in
+the <code>basic_syncbuf</code> class template, which is derived
+from <code>basic_streambuf</code>.  The class template,
+<code>basic_osyncstream</code> provides an <code>ostream</code> formatting
+interface to <code>basic_streambuf</code> in the same way
+that <code>basic_stringstream</code> provides an <code>ostream</code>
+interface to <code>basic_stringbuf</code> and
+<code>basic_fstream</code> provides an <code>ostream</code> interface
+to <code>basic_filebuf</code>.
+</p>
+
+<p>
+We follow typical stream conventions
+of <code>basic_</code> prefixes and typedefs.
+</p>
+
+<p>
+The constructor for <code>syncbuf</code>
+takes a pointer
+to a <code>basic_streambuf</code> object which will be the eventual sink for
+data written to the syncbuf. The expectation is that the syncbuf will buffer
+output until a call to <code>emit</code>, then will atomically transfer the
+data to the streambuf provided on construction. The syncbuf destructor calls
+<code>emit</code> automatically.
+</p>
+
+<p>
+The constructor for <code>osyncstream</code> takes either a pointer to a
+streambuf or a non-const reference to an ostream from which the streambuf is
+obtained.
+</p>
+
+<p>
+The wording below
+permits implementation of <code>basic_osyncstream</code>
+with either a <code>stream_mutex</code>
+from
+<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3535.html">
+N3535</a>
+or with implementations suitable for
+<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3665.html">
+N3665</a>,
+e.g. with Posix file locks
+<a href="#PSL">[PSL]</a>
+</p>
+
+<h3><a name="Feature">Feature Test</a></h3>
+
+<p>
+No header called <code>&lt;syncstream&gt;</code> exists in previous standards;
+testing for this header's existence is thus sufficient
+for testing existence of the feature.
+</p>
+
+<h2><a name="Wording">Wording</a></h2>
+
+<p>
+This wording is relative to the 2015 Technical Specification for Concurrency,
+<a href="http://www.open-std.org/jtc1/sc22/wg21/prot/14882fdis/n4577.pdf">
+N4577.</a>
+</p>
+
+<h3><a name="contents">1.1 Namespaces, headers, and modifications to standard clauses [general.namespaces]</a></h3>
+<p>Add a new entry to table 1 &mdash; C++ library headers :
+
+<blockquote>
+<p align="center">Table 1 &mdash; C++ library headers</p>
+<table>
+  <tr>
+    <td>&lt;experimental/future&gt</td><td>&lt;experimental/barrier&gt</td>
+  </tr>
+  <tr>
+    <td>&lt;experimental/latch&gt</td><td>&lt;experimental/atomic&gt</td>
+  </tr>
+  <tr>
+    <td><ins>&lt;experimental/syncstream&gt</td><td></td>
+  </tr>
+</table>
+</blockquote>
+
+
+<h3><a name="syncstream">5 Synchronized output stream [syncstream]</a></h3>
+
+<p>
+Add a new section with the following subsections.
+</p>
+
+
+<h3><a name="syncstream.overview">5.1 Overview [syncstream.overview]</a></h3>
+
+<blockquote class="stdins">
+<p>
+The header <code>&lt;experimental/syncstream&gt;</code>
+provides a mechanism to synchronize execution agents writing to the same stream.
+It defines a class template <code>basic_syncbuf</code>
+to buffer output and
+<!--atomically transfer the buffered content into a <code>basic_ostream</code> object.-->
+transfer the buffered content into an object of type
+<code>basic_streambuf&lt;charT, traits&gt;</code> atomically 
+with respect to such transfers by other 
+<code>basic_syncbuf&lt;charT,traits,Allocator&gt;</code> objects referring 
+to the same <code>basic_streambuf&lt;charT,traits&gt;</code> object.
+The transfer occurs when <code>emit()</code> is called
+and when the <code>basic_syncbuf&lt;chart,traits,Allocator&gt;</code> 
+object is destroyed. The class template <code>basic_osyncstream</code> holds a
+<code>basic_syncbuf</code> and provides formatted output to the synchronized
+stream.
+</p>
+
+<p>
+<strong>Header <code>&lt;experimental/syncstream&gt;</code> synopsis</strong>
+</p>
+
+<pre><code>namespace std {
+namespace experimental {
+inline namespace concurrency_v2 {
+
+template &lt;class charT,
+          class traits = char_traits&lt;charT&gt;,
+          class Allocator = allocator&lt;charT&gt;&gt;
+  class basic_syncbuf;
+using syncbuf  = basic_syncbuf&lt;char&gt;;
+using wsyncbuf = basic_syncbuf&lt;wchar_t&gt;;
+
+template &lt;class charT,
+          class traits = char_traits&lt;charT&gt;,
+          class Allocator = allocator&lt;charT&gt;&gt;
+  class basic_osyncstream;
+using osyncstream  = basic_osyncstream&lt;char&gt;;
+using wosyncstream = basic_osyncstream&lt;wchar_t&gt;;
+
+}}}
+</code></pre>
+</blockquote>
+
+<h3><a name="syncstream.syncbuf">5.2 Class template <code>basic_syncbuf</code> [syncstream.syncbuf]</a></h3>
+
+<blockquote class="stdins">
+<pre><code>template &lt;class charT,
+          class traits = char_traits&lt;charT&gt;,
+          class Allocator = allocator&lt;charT&gt;&gt;
+class basic_syncbuf
+  : public std::basic_stringbuf&lt;charT, traits, Allocator&gt; {
+
+public:
+  typedef charT                     char_type;
+  typedef typename traits::int_type int_type;
+  typedef typename traits::pos_type pos_type;
+  typedef typename traits::off_type off_type;
+  typedef traits                    traits_type;
+  typedef Allocator                 allocator_type;
+
+  typedef basic_streambuf&lt;charT,traits&gt; streambuf_type;
+
+  explicit
+  basic_syncbuf(streambuf_type* obuf = nullptr,
+                Allocator const &amp;allocator = Allocator());
+  basic_syncbuf(basic_syncbuf&amp;&amp; other);
+  ~basic_syncbuf();
+
+  basic_syncbuf&amp; operator=(basic_syncbuf&amp;&amp; rhs);
+  void swap(basic_syncbuf &amp;other);
+
+  bool emit();
+  streambuf_type* get_wrapped() const noexcept;
+  Allocator get_allocator() const noexcept;
+
+protected:
+  int sync() override;
+  int_type overflow(int_type c = traits::eof()) override;
+
+private:
+  streambuf_type *wrapped; // <em>exposition only</em>
+};
+
+template &lt;class charT, class traits, class Allocator&gt;
+inline void swap(basic_syncbuf&lt;charT,traits,Allocator&gt;&amp; a,
+                 basic_syncbuf&lt;charT,traits,Allocator&gt;&amp; b);
+</code></pre>
+</blockquote>
+
+<h4><a name="syncstream.sycnbuf.ctor">5.2.1 <code>basic_syncbuf</code> constructors [syncstream.syncbuf.ctor]</a></h4>
+
+<blockquote class="stdins">
+<dl>
+<dt>
+<code>explicit
+basic_syncbuf(streambuf_type* obuf = nullptr,
+              Allocator const &amp;allocator = Allocator());</code>
+</dt>
+<dd>
+
+<p><i>Effects:</i>
+Constructs the <code>basic_syncbuf</code> object and
+sets <code>wrapped</code> to <code>obuf</code>
+which will be the final destination of characters inserted into the stream.
+</p>
+
+<p><i>Remarks:</i>
+If <code>obuf == nullptr</code>, output operations on 
+<code>*this</code> will fail.
+A copy of <code>allocator</code> is used to allocate memory 
+for internal buffers.
+</p>
+
+<p>
+<i>Throws:</i>
+Nothing unless constructing a mutex or allocating memory throws.
+</p>
+
+<p>
+[<i>Note:</i> Subsequent calls to <code>emit()</code> might result in
+member functions being called on the user-provided stream buffer 
+while a lock is held.
+&mdash;<i>end note</i>]
+</p>
+
+<p><i>Postconditions:</i>
+<code>get_wrapped() == obuf. get_allocator() == allocator.</code>.
+</p>
+</dd>
+
+<dt>
+<code>basic_syncbuf(basic_syncbuf&amp;&amp; other);</code>
+</dt>
+<dd>
+
+<p><i>Effects:</i> If <code>other.get_wrapped() == nullptr</code>, equivalent
+to <code>basic_syncbuf(nullptr, other.get_allocator())</code>
+otherwise the state necessary to perform <code>other.emit()</code> is moved
+to <code>*this</code>.
+</p>
+
+<p><i>Postconditions:</i>
+The value returned by <code>this->get_wrapped()</code> is the value 
+returned by <code>other.get_wrapped()</code> prior to calling this constructor. 
+Output stored in <code>other</code> prior to calling this constructor
+will be stored in <code>*this</code> afterwards. 
+<code>other.rdbuf()->pbase() == other.rdbuf()->pptr()</code>
+and <code>other.get_wrapped() == nullptr</code>
+</p>
+
+<p>
+[<i>Note:</i>
+This constructor disassociates <code>other</code> from its wrapped stream buffer ensuring destruction of <code>other</code> produces no output.
+&mdash;<i>end note</i>]
+</p>
+</dd>
+</dl>
+</blockquote>
+
+<h4><a name="syncstream.sycnbuf.dtor">5.2.2 <code>basic_syncbuf</code> destructor [syncstream.syncbuf.dtor]</a></h4>
+
+<blockquote class="stdins">
+
+<dl>
+<dt>
+<code>~basic_syncbuf();</code>
+</dt>
+<dd>
+
+<p><i>Effects:</i> Calls <code>this->emit()</code>.
+</p>
+    
+<p><i>Throws:</i> Nothing. If an exception is thrown while writing to the
+wrapped buffer, that exception is caught and ignored.
+</p>
+</dd>
+</dl>
+</blockquote>
+
+<h4><a name="syncstream.sycnbuf.assign">5.2.3 <code>basic_syncbuf</code> assign and swap [syncstream.syncbuf.assign]</a></h4>
+
+<blockquote class="stdins">
+<dl>
+<dt>
+<code>basic_syncbuf&amp; operator=(basic_syncbuf&amp;&amp; rhs);</code>
+</dt>
+<dd>
+
+<p><i>Effects:</i>
+Calls <code>this->emit()</code>. If <code>rhs.get_wrapped() != nullptr</code>,
+the state necessary to perform <code>rhs.emit()</code> is moved
+to <code>*this</code>.
+</p>  
+
+<p><i>Returns:</i> <code>*this</code>.</p>
+
+<p><i>Postconditions:</i>
+<code>other.get_wrapped() == nullptr.</code> If
+<code>allocator_traits&lt;Allocator&gt;::propagate_on_container_move_assignment::value == true</code>,
+then <code>this->get_allocator() == other.get_allocator()</code>;
+otherwise the allocator is unchanged.
+</p>
+
+<p>
+[<i>Note:</i>
+This constructor disassociates <code>other</code> from its wrapped stream
+buffer ensuring destruction of <code>other</code> produces no output.
+&mdash;<i>end note</i>]
+</p>
+</dd>
+
+<dt>
+<code>void swap(basic_syncbuf&amp; other);</code>
+</dt>
+<dd>
+
+<p><i>Preconditions:</i>
+<code>this->get_allocator() == other.get_allocator()</code>.
+</p>
+
+<p><i>Effects:</i> Exchanges the state of <code>*this</code> and
+<code>other</code>.
+</p>
+</dd>
+
+<dt>
+<code>template &lt;class charT, class traits, class Allocator&gt;<br/>
+&nbsp;&nbsp;void swap(basic_syncbuf&lt;charT,traits,Allocator&gt;&amp; a,
+                      basic_syncbuf&lt;charT,traits,Allocator&gt;&amp; b);
+</code>
+</dt>
+<dd>
+<p><i>Effects:</i> As if by <code>a.swap(b)</code>.
+</p>
+</dd>
+</dl>
+</blockquote>
+    
+<h4><a name="syncstream.syncbuf.mfun">5.2.4 <code>basic_syncbuf</code> member functions [syncstream.syncbuf.mfun]</a></h4>
+
+<blockquote class="stdins">
+<dl>
+
+<dt>
+<code>bool emit();</code>
+</dt>
+<dd>
+
+<p><i>Effects:</i>
+Atomically transfers the contents of the internal buffer
+to the stream buffer <code>*wrapped</code>,
+so that they appear in the output stream as a contiguous sequence of characters.
+If and only if a call was made to <code>this->sync()</code>,&nbsp;  
+<code>wrapped->pubsync()</code> is called.
+</p>
+
+<p><i>Returns:</i> true if <code>wrapped != nullptr</code>, all of the
+buffered characters were successfully transferred, and the call
+to <code>wrapped->pubsync()</code> (if any) succeeded; otherwise false.
+</p>
+     
+<p><i>Synchronization:</i>
+All <code>emit()</code> calls transferring characters 
+to the same stream buffer object
+appear to execute in a total order consistent with <i>happens-before</i> 
+where each <code>emit()</code> call <i>synchronizes-with</i> subsequent 
+<code>emit()</code> calls in that total order.
+</p>
+
+<p><i>Remarks:</i>
+May call member functions of <code>wrapped</code> while holding a lock
+uniquely associated with <code>wrapped</code>.
+</p>
+</dd>
+
+<dt>
+<code>streambuf_type* get_wrapped() const noexcept;</code>
+</dt>
+<dd>
+<p><i>Returns:</i>
+The most recent value of <code>wrapped</code>, as set in the constructor or
+assignment operator.
+</p>
+</dd>
+
+<dt>
+<code>Allocator* get_allocator() const noexcept;</code>
+</dt>
+<dd>
+<p><i>Returns:</i>
+The most recent allocator, as set in the constructor or assignment operator.
+</p>
+</dd>
+</dl>
+</blockquote>
+
+<h4><a name="syncstream.syncbuf.virtuals">5.2.5 <code>basic_syncbuf</code> overridden virtual functions [syncstream.syncbuf.virtuals]</a></h4>
+
+<blockquote class="stdins">
+<dl>
+<dt>
+<code>int sync() override;</code>
+</dt>
+
+<dd>
+<p><i>Effects:</i>
+Record the fact that user desires that the buffer be flushed.
+The actual flush is delayed until a call to <code>emit()</code>.
+<p>
+
+<p><i>Returns:</i> 0.
+</dd>  
+
+<dt>
+<code>int_type overflow(int_type c = traits::eof()) override;</code>
+</dt>
+
+<dd>
+
+<p>
+<!-- The following is borrowed from basic_streambuf. -->
+<i>Effects:</i> Appends the character designated by c to the output sequence,
+if possible, in one of the following ways (in order):
+</p>
+<ul class="dash">
+<li>
+  If <code>wrapper == nullptr</code>, signals failure by
+  returning <code>traits::eof()</code>.
+</li>
+<li>
+  If <code>traits::eq_int_type(c, traits::eof())</code> returns false and if
+  either the output sequence has a write position available or the function
+  makes a write position available by allocating storage. The function
+  then calls <code>sputc(c)</code> and signals success by returning c.
+</li>
+<li>
+  If <code>traits::eq_int_type(c, traits::eof())</code> returns true, there is
+  no character to append. Signals success by returning a value other than
+  <code>traits::eof()</code>.
+</li>
+</ul>
+
+<p>
+<i>Returns:</i> <code>traits::eof()</code> to indicate failure.
+</p>
+</dd>
+
+</dl>
+</blockquote>
+
+<h3><a name="syncstream.osyncstream">5.3 Class template <code>basic_osyncstream</code> [syncstream.osyncstream]</a></h3>
+
+<blockquote class="stdins">
+<pre><code>template &lt;class charT,
+          class traits = char_traits&lt;charT&gt;,
+          class Allocator = allocator&lt;charT&gt;&gt;
+class basic_osyncstream
+  : public basic_ostream&lt;charT,traits&gt;
+{
+public:
+  typedef charT                     char_type;
+  typedef typename traits::int_type int_type;
+  typedef typename traits::pos_type pos_type;
+  typedef typename traits::off_type off_type;
+  typedef traits                    traits_type;
+  typedef Allocator                 allocator_type;
+
+  typedef basic_streambuf&lt;charT,traits&gt; streambuf_type;
+
+  explicit basic_osyncstream(basic_streambuf&lt;CharT,traits&gt; *obuf = nullptr,
+                             Allocator const &amp;allocator = Allocator());
+  explicit basic_osyncstream(basic_ostream&lt;charT,traits&gt;&amp; os,
+                             Allocator const &amp;allocator = Allocator());
+  basic_osyncstream(basic_osyncstream&amp;&amp; other);
+  ~basic_osyncstream();
+  basic_osyncstream&amp; operator=(basic_osyncstream&amp;&amp; rhs);
+  void emit();
+  streambuf_type* get_wrapped() const noexcept;
+  Allocator get_allocator() const noexcept;
+
+private:
+  basic_syncbuf&ltcharT, traits, Allocator&gt; sb; // <i>exposition only</i>
+};
+</code></pre>
+
+<!--<p>
+The class template <code>basic_osyncstream</code>
+supports buffering into an internal buffer
+and then
+transferring the contents of the buffer
+to a <code>basic_ostream</code> atomically with respect to other 
+<code>basic_osyncstream</code> objects referring to the same <code>basic_ostream</code>.
+</p>-->
+
+<p>
+<code>Allocator</code> shall meet the allocator requirements [allocator.requirements]. 
+</p>
+
+<p>
+[<i>Example:</i>
+Use a named variable within a block statement for streaming
+across multiple statements.
+</p>
+<pre class="example"><code>{
+  osyncstream bout(cout);
+  bout &lt;&lt; "Hello, ";
+  bout &lt;&lt; "World!";
+  bout &lt;&lt; endl;
+}</code></pre>
+<p>
+&mdash;<i>end example</i>]
+</p>
+
+<p>
+[<i>Example:</i>
+Use a temporary object for streaming within a single statement.
+</p>
+<pre class="example"><code>osyncstream(cout) &lt;&lt; "Hello, " &lt;&lt; "World!" &lt;&lt; endl;</code></pre>
+<p>
+&mdash;<i>end example</i>]
+</p>
+
+</blockquote>
+
+
+<h4><a name="synstream.osyncstream.ctor">5.3.1 <code>basic_osyncstream</code> Constructors [syncstream.osyncstream.ctor]</a></h4>
+
+<blockquote class="stdins">
+
+<dl>
+<dt>
+<code>explicit basic_osyncstream(basic_ostream&lt;charT,traits&gt;&amp; *obuf, Allocator const &amp;allocator=Allocator());</code>
+</dt>
+<dd>
+
+<p><i>Effects:</i>
+Constructs an object of class <code>basic_osyncstream</code>, initializing
+the  base class with <code>basic_ostream(&amp;sb)</code> and
+initializing <code>&sb</code> with
+<code>basic_syncbuf&lt;charT,traits,Allocator&gt(obuf, allocator)</code>. 
+</p>
+
+<p>
+[<i>Note:</i> Subsequent calls to <code>emit()</code> might result in
+member functions being called on the user-provided stream buffer 
+while a lock is held.
+&mdash;<i>end note</i>]
+</p>
+</dd>
+
+<dt>
+<code>explicit basic_osyncstream(basic_ostream&lt;charT,traits&gt;&amp; os,
+                                 Allocator const &amp;allocator = Allocator());
+</code>
+</dt>
+<dd>
+<p><i>Effects:</i>
+<code>basic_osyncstream(os.rdbuf(), allocator)</code>
+</dd>
+
+<dt>
+<code>basic_osyncstream(basic_osyncstream&amp;&amp; other);</code>
+</dt>
+<dd>
+
+<p><i>Effects:</i>
+Move constructs from the rvalue <code>other</code>. This is accomplished by
+move constructing the base class, and the contained <code>basic_syncbuf</code>.
+Next <code>basic_ostream&lt;charT, traits&gt;::set_rdbuf(&sb)</code> is called
+to install the contained <code>basic_syncbuf</code>.
+</p>
+</dd>
+
+</dl>
+
+</blockquote>
+
+
+<h4><a name="synstream.osyncstream.dtor">5.3.2 <code>basic_osyncstream</code> Destructor [synstream.osyncstream.dtor]</a></h4>
+
+<blockquote class="stdins">
+
+<dl>
+
+<dt><code>~basic_osyncstream();</code></dt>
+<dd>
+
+<p><i>Effects:</i>
+Destroys <code>sb</code>, which results in <code>sb.emit()</code> being called.
+</p>
+
+</dd>
+</dl>
+
+</blockquote>
+<h4><a name="synstream.osyncstream.assign">5.3.3 <code>basic_osyncstream</code> Assignment [synstream.osyncstream.assign]</a></h4>
+
+<blockquote class="stdins">
+
+<dl>
+
+<dt>
+<code>basic_osyncstream& operator=(basic_osyncstream&amp;&amp; rhs);</code>
+</dt>
+<dd>
+
+<p><i>Effects:</i>
+Move assigns the base and members of <code>*this</code> from the base and
+corresponding members of <code>rhs</code>.
+</p>
+
+<p><i>Returns:</i> <code>*this</code>.</p>
+  
+<p><i>Postcondition:</i>
+<code>nullptr == rhs.get_wrapped()</code>. 
+<code>this->get_wrapped()</code> returns the value previously returned by 
+<code>rhs.get_wrapped()</code>
+</p>
+
+</dd>
+</dl>
+
+</blockquote>
+
+<h4><a name="syncstream.osyncstream.mfun">5.3.4 <code>basic_osyncstream</code>member functions [syncstream.osyncstream.mfun]</a></h4>
+
+<blockquote class="stdins">
+
+<dl>
+<dt>
+<code>void emit();</code>
+</dt>
+<dd>
+
+<p><i>Effects:</i>
+Calls <code>sb.emit()</code>. If this call returns <code>false</code>,
+calls <code>setstate(ios::badbit)</code>.
+</p>
+
+<p>
+[<i>Example:</i>
+The function <code>emit()</code> can be used to catch exceptions 
+from operations on the underlying stream.
+</p>
+<pre class="example"><code>{
+  osyncstream bout(cout);
+  bout &lt;&lt; "Hello, " &lt;&lt; "World!" &lt;&lt; endl;
+  try {
+    bout.emit();
+  } catch ( ... ) {
+    // stuff
+  }
+}</code>
+</pre>
+<p>
+&mdash;<i>end example</i>]
+</p>
+
+</dd>
+
+<dt><code>basic_ostream&lt;charT,traits&gt;&amp;* get_wrapped() const noexcept;</code></dt>
+<dd>
+
+<p><i>Returns:</i>
+<code>sb.get_wrapped()</code>
+</p>
+
+<p>[<i>Example:</i>
+Obtaining the wrapped stream buffer with <code>get_wrapped()</code> 
+allows wrapping it again with an <code>osyncstream</code>.
+For example,
+</p>
+<pre class="example"><code>{
+  osyncstream bout1(cout);
+  bout1 &lt;&lt; "Hello, ";
+  {
+    osyncstream bout2(bout1.get_wrapped());
+    bout2 &lt;&lt; "Goodbye, " &lt;&lt; "Planet!" &lt;&lt; endl;
+  }
+  bout1 &lt;&lt; "World!" &lt;&lt; endl;
+}</code></pre>
+<p>
+produces the <em>uninterleaved</em> output
+</p>
+<pre class="example"><code>Goodbye, Planet!
+Hello, World!
+</code></pre>
+<p>
+&mdash;<i>end example.</i>]
+</p>
+</dd>
+
+<dt><code>Allocator* get_allocator() const noexcept;</code></dt>
+<dd>
+
+<p><i>Returns:</i>
+<code>sb.get_allocator()</code>
+</p>
+
+</dd>
+</dl>
+
+</blockquote>
+
+<h2><a name="implementation">Implementation</a></h2>
+
+<p>
+An example implementations is available on 
+<a href="https://github.com/PeterSommerlad/SC22WG21_Papers/tree/master/workspace/p0053_basic_osyncstreambuf">
+https://github.com/PeterSommerlad/SC22WG21_Papers/tree/master/workspace/p0053_basic_osyncstreambuf</a>.
+</p>
+<p>The allocator semantics are not fully implemented because the prototype
+implementation relies <code>stringstream</code> which does not fully implement
+correct allocator semantics.
+</p>
+
+<h2><a name="Revisions">Revisions</a></h2>
+<p>
+This paper revises
+<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2016/p0053r2.html">
+P0053R2 C++ Synchronized Buffered Ostream</a>
+</p>
+<ul>
+  <li><p>
+      Rebased against the concurrency TS,
+      <a href="http://www.open-std.org/jtc1/sc22/wg21/prot/14882fdis/n4577.pdf">
+        N4577.</a>
+  </p></li>
+  <li><p>
+      Restructured into separate <code>streambuf</code> and
+      <code>ostream</code> classes, consistent with <code>stringstream</code>
+      and <code>fstream</code>
+  </p></li>
+  <li><p>
+      Added precision to wording.
+  </p></li>
+  <li><p>
+      Updated implementation.
+  </p></li>
+</ul>
+
+<p>
+P0053R2 revises
+<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2016/p0053r1.html">
+P0053R1 C++ Synchronized Buffered Ostream</a>
+</p>
+<ul>
+<li>
+<p>
+Provide a typedef for the wrapped stream buffer and use it to shorten the specification 
+as suggested by Daniel Kr&uuml;gler.
+</p>
+</li>
+<li>
+<p>
+Provide move construction and move assignment and specify the moved-from state to be 
+detached from the wrapped stream buffer.
+</p>
+</li>
+<li>
+<p>
+Rename <code>get()</code> to <code>get_wrapped()</code> and provide noexcept specification.
+</p>
+</li>
+<li>
+<p>
+Changed to explicitly rely on wrapping a stream buffer, 
+instead of an ostream object and adjust explanations accordingly.
+</p>
+</li>
+</ul>
+<p>
+P0053R1 revises
+<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2015/p0053r0.html">
+P0053R0 C++ Synchronized Buffered Ostream</a>
+</p>
+<ul>
+<li>
+<p>
+Add remark to note that exchanging the stream buffer while the stream is wrapped causes
+undefined behavior and added a note to warn stream buffer implementers about the lock 
+being held in <code>emit()</code>. Call setstate(badbit) if IO errors occur in emit().
+</p>
+</li>
+<li>
+<p>
+Replace code references to <code>basic_streambuf</code> by the 
+term <i>stream buffer</i> introduced in [stream.buffers].
+</p>
+</li>
+<li>
+<p>
+Provide an example implementation.
+</p>
+</li>
+<li>
+<p>
+The lock is to be associate to the underlying <code>basic_streambuf</code> instead of the <code>basic_stream</code>.
+</p>
+</li>
+<li>
+<p>
+Added an <code>Allocator</code> constructor parameter.
+</p>
+</li>
+<li>
+<p>
+Moves destructor example to <code>emit()</code>.
+</p>
+</li>
+<li>
+<p>
+Clarifies wording about synchronization and flushing (several times).
+</p>
+</li>
+<li>
+<p>
+List the new header in corresponding table.
+</p>
+</li>
+<li>
+<p>
+Provide type aliases in <code>&lt;iosfwd&gt;</code>.
+</p>
+</li>
+
+<li>
+<p>
+Removed copy constructor in favor of providing <code>get()</code>.
+</p>
+</li>
+<li>
+<p>
+Notify that move construction and assignment is deleted.
+</p>
+</li>
+<li>
+<p>
+Moved class noteflush_streambuf into an implementation note.
+</p>
+</li>
+<li>
+<p>
+Add a design subsection that states that
+a header test is a sufficient feature test.
+</p>
+</li>
+</ul>
+
+
+<p>
+P0053R0 revises
+<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2015/P0053R0.html">
+N4187 C++ Ostream Buffers</a>
+</p>
+
+<ul>
+
+<li><p>
+Updated introduction with recent history.
+</p></li>
+
+<li><p>
+Rename <code>ostream_buffer</code> to <code>osyncstream</code>
+to reflect its appearance is more like a stream than like a buffer.
+</p></li>
+
+<li><p>
+Add an example of using <code>osyncstream</code> as a temporary object.
+</p></li>
+
+<li><p>
+Add an example of a <code>osyncstream</code>
+constructed with another <code>osyncstream</code>.
+</p></li>
+
+<li><p>
+Clarify the behavior of nested <code>osyncstream</code> executions.
+</p></li>
+
+<li><p>
+Clarify the behavior of exceptions
+occuring with the <code>osyncstream</code> destructor.
+</p></li>
+
+<li><p>
+Clarify the deferral of flush from the 
+<code>osyncstream</code>'s <code>streambuf</code>
+to the final <code>basic_ostream</code>.
+</p></li>
+
+<li><p>
+Limit the number of references to <code>noteflush_stringbuf</code>
+in anticipation of the committee removing it from the specification.
+</p></li>
+
+<li><p>
+Rename <code>noteflush_stringbuf</code>
+to <code>noteflush_streambuf</code> to hide possible implementation details.
+</p></li>
+
+<li><p>
+Change the base class of <code>noteflush_streambuf</code>
+from <code>basic_stringbuf</code> to <code>basic_streambuf</code>.
+</p></li>
+
+</ul>
+
+<p>
+<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2014/n4187.html">
+N4187</a>
+revised
+<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2014/n4069.html">
+N4069 C++ Ostream Buffers</a>
+</p>
+
+<ul>
+<li><p>
+Added note to sync as suggested by BSI via email.
+</p></li>
+</ul>
+
+<p>
+<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2014/n4069.html">
+N4069</a>
+revised
+<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2014/n3978.html">
+N3978 C++ Ostream Buffers</a>
+</p>
+
+<ul>
+
+<li><p>
+Added a Design section.
+</p></li>
+
+<li><p>
+Clarify the reference capturing behavior
+of the <code>ostream_buffer</code> constructors.
+</p></li>
+
+<li><p>
+Added noexcept and const as appropriate to members.
+</p></li>
+
+<li><p>
+Added note on throwing wrapped streams.
+</p></li>
+
+<li><p>
+Change the
+<code>noteflush_stringbuf</code>
+public member variable
+<code>needsflush</code>
+to a public member query function <code>flushed</code>.
+</p></li>
+
+<li><p>
+Removed the public member function <code>noteflush_stringbuf::clear</code>.
+</p></li>
+
+<li><p>
+Minor synopsis formatting changes.
+</p></li>
+
+<li><p>
+Incorporated feedback from SG1 and Dietmar K&uuml;hl in specific in Rapperswil.
+</p></li>
+</ul>
+
+<p>
+<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2014/n3978.html">
+N3978</a> revised
+<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2013/n3892.html">
+N3892 C++ Ostream Buffers</a>
+</p>
+
+<ul>
+
+<li><p>
+Flush the ostream if and only if the <code>ostream_buffer</code> was flushed.
+</p></li>
+
+<li><p>
+Add the <code>clear_for_reuse</code> function.
+</p></li>
+
+<li><p>
+Change the design from inheriting from <code>basic_ostream</code>
+to using a <code>noteflush_stringbuf</code>,
+which is a slightly modified <code>basic_stringbuf</code>.
+The modification is to note the flush rather than act upon it.
+</p></li>
+
+</ul>
+
+<p>
+<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2013/n3892.html">
+N3892</a> revised
+<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2013/n3750.html">
+N3750 C++ Ostream Buffers</a>
+</p>
+
+<ul>
+
+<li><p>
+Change name to <code>basic_ostream_buffer</code>
+and add the usual typedefs.
+</p></li>
+
+<li><p>
+Change interface to inherit from <code>basic_ostringstream</code>
+rather than provide access to a member of that type.
+</p></li>
+
+<li><p>
+Add a Revisions section.
+</p></li>
+
+</ul>
+
+
+<h2><a name="References">References</a></h2>
+
+<dl>
+
+<dt><a name="PSL">[PSL]</a></dt>
+<dd>
+<cite>The Open Group Base Specifications Issue 6,
+IEEE Std 1003.1, 2004 Edition</cite>,
+functions, flockfile,
+<a href="http://pubs.opengroup.org/onlinepubs/009695399/functions/flockfile.html">
+http://pubs.opengroup.org/onlinepubs/009695399/functions/flockfile.html</a>
+</dd>
+
+</dl>
+
+
+
+</body></html>

--- a/workspace/p0053_basic_osyncstreambuf/src/globalstreambuflocks.cpp
+++ b/workspace/p0053_basic_osyncstreambuf/src/globalstreambuflocks.cpp
@@ -1,4 +1,5 @@
-/*
+/* -*- mode: c++; c-basic-offset: 2; tab-width: 2 -*-
+ *
  * globalstreambuflocks.cpp
  *
  *  Created on: 22.06.2016

--- a/workspace/p0053_basic_osyncstreambuf/src/globalstreambuflocks.h
+++ b/workspace/p0053_basic_osyncstreambuf/src/globalstreambuflocks.h
@@ -1,3 +1,5 @@
+// -*- mode: c++; c-basic-offset: 2; tab-width: 2 -*-
+
 #ifndef GLOBALSTREAMBUFLOCKS_H_
 #define GLOBALSTREAMBUFLOCKS_H_
 


### PR DESCRIPTION
I have modified the p0053_basic_osyncstreambuf source code to make `basic_syncbuf` a visible, standard-conforming type.  One of the tests is failing, but I don't understand why it should ever have worked.

I have also updated P0053 and checked in R3.  In addition to `basic_streambuf`, I have generally tightened up the standardese.