### PR TITLE
Added missing header that causes compilation failure

### DIFF
--- a/workspace/P0052_scope_exit/src/unique_resource.h
+++ b/workspace/P0052_scope_exit/src/unique_resource.h
@@ -24,6 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 #include "_scope_guard_common.h"
+#include "scope_exit.h"
 #include <type_traits>
 
 #include <utility>


### PR DESCRIPTION
Presently, `#include <unique_resource.h>` won't compile, as it is missing `#include <scope_exit.h>`. This patch adds the header.